### PR TITLE
Align the suggested_books submenu next to the suggested_books button

### DIFF
--- a/navbar.css
+++ b/navbar.css
@@ -13,6 +13,9 @@
     #suggested_books_button:hover #suggested_books_list{
         opacity: 1;
     }
+    #suggested_books_list{
+        top: 0;
+    }
 	.dropdown-menu .dropdown-toggle:after{
 		border-top: .3em solid transparent;
 	    border-right: 0;


### PR DESCRIPTION
This leaves the submenu for suggested books level with the button.
![image](https://user-images.githubusercontent.com/56333467/111386919-2fb55380-866a-11eb-9b35-6260c76578bd.png)
